### PR TITLE
Use cPickle if possible. It's ~4 times faster.

### DIFF
--- a/pylookup.py
+++ b/pylookup.py
@@ -15,7 +15,10 @@ from __future__ import with_statement
 
 import sys
 import re
-import pickle
+try:
+    import cPickle as pickle
+except:
+    import pickle
 import formatter
 
 from os.path import join, dirname, exists, abspath, expanduser


### PR DESCRIPTION
Old version:

```
./pylookup.py -l ljust  0.89s user 0.02s system 99% cpu 0.917 total
./pylookup.py -l ljust  0.88s user 0.02s system 99% cpu 0.912 total
```

This patch:

```
./pylookup.py -l ljust  0.22s user 0.02s system 97% cpu 0.241 total
./pylookup.py -l ljust  0.22s user 0.01s system 98% cpu 0.235 total
```

Maybe it is good idea to rewrite search backend...
I think calling `pickle.load` once, instead of more than 10,000 times would be better.
