### PR TITLE
Python 2.x support

### DIFF
--- a/pylookup.py
+++ b/pylookup.py
@@ -25,7 +25,7 @@ import formatter
 from os.path import join, dirname, exists, abspath, expanduser
 from contextlib import closing
 
-if sys.version_info.major == 3:
+if sys.version_info[0] == 3:
     import html.parser    as htmllib
     import urllib.parse   as urlparse
     import urllib.request as urllib


### PR DESCRIPTION
Hi, I was running into problems trying out pylookup on 2.6. Interestingly the exception from pylookup.py was being cut up and displayed as suggestions :) Once I fixed the cause of the exception, turns out 2.6 docs aren't present on python.org in the archives directory, so I switched to 2.7. Working fine now.
