### PR TITLE
one little elisp function

### DIFF
--- a/pylookup.el
+++ b/pylookup.el
@@ -282,5 +282,24 @@
   (with-temp-buffer (write-file pylookup-db-file))
   (mapc (lambda (s) (pylookup-update s t)) pylookup-html-locations))
 
+;;;###autoload
+(defun pylookup-lookup-at-point ()
+  "Query the for string with help of word read at point and call `pylookup-lookup'"
+  (interactive)
+  (let* ((default-word (thing-at-point 'word))
+         (default-prompt (concat "Lookup Word "
+                                 (if default-word
+                                     (concat "(" default-word ")") nil)
+                                 ": "))
+         (pylookup-query
+          (funcall #'(lambda (str)
+                       "Remove Whitespace from beginning and end of a string."
+                       (replace-regexp-in-string "^[ \n\t]*\\(.*?\\)[ \n\t]*$"
+                                                 "\\1"
+                                                 str))
+                   (read-string default-prompt nil nil default-word))))
+    (if (= (length pylookup-query) 0) nil
+      (pylookup-lookup pylookup-query))))
+
 (provide 'pylookup)
 ;;; pylookup.el ends here


### PR DESCRIPTION
One problem I had was if I want search for some thing, pylookup-lookup does n't allow me enter keyword if ido-mode is enabled.

this function helps to solve that problem. After writing this I found that first part of this function is very similar to the pylookup-lookup itself.

If you think repetition of code is not so good please feel free to dismiss/close this pull. But I really want to have a way to search the database instead of being forced to choose from a list. 
