### PR TITLE
fixed resolution of parent directory name when calling IndexProcessor

### DIFF
--- a/pylookup.py
+++ b/pylookup.py
@@ -231,7 +231,7 @@ def update(db, urls, append=False):
                     if not issubclass(type(index), str):
                         index = index.decode()
 
-                    parser = IndexProcessor(writer, dirname(url))
+                    parser = IndexProcessor(writer, dirname(index_url))
                     with closing(parser):
                         parser.feed(index)
 


### PR DESCRIPTION
Hi there,

I had a bug when indexing an offline documentation with the following command:
pylookup -u python-2.7.3-docs-html
The indexing processed just fine but the absolute paths in the DB did not contained the directory _python-2.7.3-docs-html_

Here is a fix to get the right parent directory when IndexProcessor is called.

Cheers,
syl20bnr
